### PR TITLE
Add "--socket=gpg-agent" to manifest to allow using pinentry

### DIFF
--- a/com.github.git_cola.git-cola.yml
+++ b/com.github.git_cola.git-cola.yml
@@ -16,6 +16,7 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=home
   - --socket=ssh-auth
+  - --socket=gpg-agent
   - --system-talk-name=org.freedesktop.UDisks2
 
 modules:


### PR DESCRIPTION
Fixes #41.